### PR TITLE
Remove `-O` flag from `curl`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -42,11 +42,11 @@
 - ### 🐙 [GitHub Releases](https://github.com/5ouma/mli/releases)
 
   ```shell
-  curl -OL https://github.com/5ouma/mli/releases/latest/download/mli_Darwin_x86_64.tar.gz | tar -x mli
+  curl -L https://github.com/5ouma/mli/releases/latest/download/mli_Darwin_x86_64.tar.gz | tar -x mli
   ```
 
   ```shell
-  curl -OL https://github.com/5ouma/mli/releases/latest/download/mli_Darwin_arm64.tar.gz | tar -x mli
+  curl -L https://github.com/5ouma/mli/releases/latest/download/mli_Darwin_arm64.tar.gz | tar -x mli
   ```
 
 <br /><br />


### PR DESCRIPTION
The downloaded tarball will be passed to `tar` via pipe.