### PR TITLE
Add `contents: write` permission to the workflow

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
To push a branch not only default requires permission.