### PR TITLE
Remove execute permission from a saved file

### DIFF
--- a/lib/io.go
+++ b/lib/io.go
@@ -16,7 +16,7 @@ func (loginItems *LoginItems) Save(path string, force bool) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(path, data, 0644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

**Issue:** close #29

### Checklist

- [x] This Pull Request introduces a new feature.
- [ ] This Pull Request fixes a bug.

### Description

Since I specified as `os.ModePerm`, all permission was added.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/mli/blob/main/.github/CODE_OF_CONDUCT.md).
