### PR TITLE
Loosen timeout minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
   format-check:
     name: 📝 Format Check
     runs-on: Ubuntu-Slim
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository
@@ -104,7 +104,7 @@ jobs:
     environment:
       name: CI
       deployment: false
-    timeout-minutes: 1
+    timeout-minutes: 2
 
     steps:
       - name: 🚚 Check out repository


### PR DESCRIPTION
### ⚠️ Issue <!-- rumdl-disable-line MD041 -->

close #

<br />

### ✏️ Description

One minute is too tight to finish workflows completely.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/mli/blob/main/.github/CODE_OF_CONDUCT.md).
