### PR TITLE
Remove -w GoReleaser ldflag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,6 @@ builds:
       - -trimpath
     ldflags:
       - -s
-      - -w
     goos:
       - darwin
     goarch:


### PR DESCRIPTION
### ⚠️ Issue <!-- rumdl-disable-line MD041 -->

close #

<br />

### ✏️ Description

It's now folded into the -s flag.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/mli/blob/main/.github/CODE_OF_CONDUCT.md).
